### PR TITLE
Update bot/middlewares/__init__.py

### DIFF
--- a/bot/middlewares/__init__.py
+++ b/bot/middlewares/__init__.py
@@ -19,8 +19,6 @@ def register_middlewares(dp: Dispatcher) -> None:
 
     dp.message.middleware(AuthMiddleware())
 
-    dp.message.middleware(ACLMiddleware(i18n=_i18n))
-    dp.callback_query.middleware(ACLMiddleware(i18n=_i18n))
-    dp.inline_query.middleware(ACLMiddleware(i18n=_i18n))
+    ACLMiddleware(i18n=_i18n).setup(dp)
 
     dp.callback_query.middleware(CallbackAnswerMiddleware())


### PR DESCRIPTION
It fixed bug "I18n context is not set" for me

and aiogram recommends this method to setup I18nMiddleware

https://docs.aiogram.dev/en/dev-3.x/utils/i18n.html#aiogram.utils.i18n.middleware.I18nMiddleware.setup