### PR TITLE
Avoid crash when Amplitude API token is empty

### DIFF
--- a/bot/services/analytics.py
+++ b/bot/services/analytics.py
@@ -16,10 +16,13 @@ _Func = TypeVar("_Func")
 
 
 class AnalyticsService(metaclass=SingletonMeta):
-    def __init__(self, logger: AbstractAnalyticsLogger) -> None:
+    def __init__(self, logger: AbstractAnalyticsLogger | None) -> None:
         self.logger = logger
 
     async def _track_error(self, user_id: int, error_text: str) -> None:
+        if not self.logger:
+            return
+
         await self.logger.log_event(
             BaseEvent(
                 user_id=user_id,
@@ -95,9 +98,7 @@ class AnalyticsService(metaclass=SingletonMeta):
 
         return decorator
 
-if settings.AMPLITUDE_API_KEY:
-    logger = AmplitudeTelegramLogger(api_token=settings.AMPLITUDE_API_KEY)
-else:
-    logger = None
+
+logger = AmplitudeTelegramLogger(api_token=settings.AMPLITUDE_API_KEY) if settings.AMPLITUDE_API_KEY else None
 
 analytics = AnalyticsService(logger)

--- a/bot/services/analytics.py
+++ b/bot/services/analytics.py
@@ -39,6 +39,9 @@ class AnalyticsService(metaclass=SingletonMeta):
         ) -> Callable[..., Awaitable[_Func]]:
             @wraps(handler)
             async def wrapper(update: Message | CallbackQuery, *args: Any) -> Any:
+                if not self.logger:
+                    return await handler(update, *args)
+
                 if (isinstance(update, (Message, CallbackQuery))) and update.from_user:
                     user_id = update.from_user.id
                     first_name = update.from_user.first_name
@@ -92,5 +95,9 @@ class AnalyticsService(metaclass=SingletonMeta):
 
         return decorator
 
+if settings.AMPLITUDE_API_KEY:
+    logger = AmplitudeTelegramLogger(api_token=settings.AMPLITUDE_API_KEY)
+else:
+    logger = None
 
-analytics = AnalyticsService(AmplitudeTelegramLogger(api_token=settings.AMPLITUDE_API_KEY))
+analytics = AnalyticsService(logger)


### PR DESCRIPTION
This pull request prevents the bot from throwing an error when there is no Amplitude API token. This makes it easier to run the bot to see how it works, because you don't have to register on Amplitude and get a token.