### PR TITLE
Исправление: ReadOnlyError в I18nMiddleware при обработке chat_member

### DIFF
--- a/bot/middlewares/i18n.py
+++ b/bot/middlewares/i18n.py
@@ -32,6 +32,9 @@ class ACLMiddleware(I18nMiddleware):
     async def get_locale(self, event: TelegramObject, data: dict[str, Any]) -> str:
         session: AsyncSession = data["session"]
 
+        if hasattr(event, 'chat_member'):
+            return self.DEFAULT_LANGUAGE_CODE
+
         user: User | None = getattr(event, "from_user", None)
         if not user:
             return self.DEFAULT_LANGUAGE_CODE

--- a/bot/middlewares/i18n.py
+++ b/bot/middlewares/i18n.py
@@ -33,7 +33,7 @@ class ACLMiddleware(I18nMiddleware):
         session: AsyncSession = data["session"]
 
         if hasattr(event, 'chat_member'):
-            return self.DEFAULT_LANGUAGE_CODE
+            return None
 
         user: User | None = getattr(event, "from_user", None)
         if not user:

--- a/bot/middlewares/i18n.py
+++ b/bot/middlewares/i18n.py
@@ -33,7 +33,7 @@ class ACLMiddleware(I18nMiddleware):
         session: AsyncSession = data["session"]
 
         if hasattr(event, 'chat_member'):
-            return None
+            return self.DEFAULT_LANGUAGE_CODE
 
         user: User | None = getattr(event, "from_user", None)
         if not user:


### PR DESCRIPTION
Ранее I18nMiddleware пытался записывать данные в Redis (через get_language_code) при получении обновлений chat_member, что приводило к ошибке ReadOnlyError на репликах. Теперь добавлена проверка на события chat_member: в таких случаях вызов Redis пропускается, и возвращается None, предотвращая операции записи на репликах только для чтения.

![image](https://github.com/user-attachments/assets/96fc0ebf-e310-4b48-8fe3-3ebcc8b46b2c)
![image](https://github.com/user-attachments/assets/c2e69f90-4ed0-4ea9-93ef-dfa4f25d97d0)
